### PR TITLE
feat(notifications): add endpoint to fetch notification logs from MS

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { ChartModule } from './modules/chart/chart.module'
 import { ClientModule } from './modules/client/client.module'
 import { PrismaModule } from './modules/database/prisma.module'
 import { InsuranceCompanyModule } from './modules/insurance-company/insurance-company.module'
+import { NotificationsModule } from './modules/notifications/notifications.module'
 import { ProductTypeModule } from './modules/product-type/product-type.module'
 import { ProductModule } from './modules/product/product.module'
 import { UserModule } from './modules/user/user.module'
@@ -39,6 +40,7 @@ import { CustomThrottlerGuard } from './common/auth/auth.throttler.guard'
     ChartTypeModule,
     ChartModule,
     DashboardModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/modules/notifications/dto/create-template.dto.ts
+++ b/backend/src/modules/notifications/dto/create-template.dto.ts
@@ -1,0 +1,37 @@
+import { CreateTemplateInput } from '@/modules/notifications/inputs/create-template.input'
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+import { IsBoolean, IsObject, IsOptional, IsString, ValidateIf } from 'class-validator'
+
+export class CreateTemplateDto implements CreateTemplateInput {
+  @ApiProperty({ description: 'Template name' })
+  @IsString({ message: 'O nome do template deve ser um texto.' })
+  name!: string
+
+  @ApiProperty({ description: 'Template description', type: String, nullable: true })
+  @ValidateIf((_, value) => value !== null)
+  @IsString({ message: 'A descrição do template deve ser um texto.' })
+  description!: string | null
+
+  @ApiProperty({ description: 'E-mail subject' })
+  @IsString({ message: 'O assunto do template deve ser um texto.' })
+  subject!: string
+
+  @ApiProperty({ description: 'Template body (HTML)' })
+  @IsString({ message: 'O corpo do template deve ser um texto.' })
+  body!: string
+
+  @ApiPropertyOptional({ description: 'Variables accepted by the template' })
+  @IsOptional()
+  @IsObject({ message: 'O esquema de variáveis deve ser um objeto.' })
+  variableSchema?: Record<string, string>
+
+  @ApiPropertyOptional({ description: 'Whether the template is active' })
+  @IsOptional()
+  @IsBoolean({ message: 'O campo ativo deve ser um booleano.' })
+  isActive?: boolean
+
+  @ApiPropertyOptional({ description: 'Notification type id' })
+  @IsOptional()
+  @IsString({ message: 'O ID do tipo de notificação deve ser um texto.' })
+  notificationTypeId?: string
+}

--- a/backend/src/modules/notifications/dto/notification-log-response.dto.ts
+++ b/backend/src/modules/notifications/dto/notification-log-response.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+
+class NotificationLogRelationResponseDto {
+  @ApiProperty()
+  id!: string
+
+  @ApiProperty()
+  name!: string
+}
+
+export class NotificationLogResponseDto {
+  @ApiProperty()
+  id!: string
+
+  @ApiProperty()
+  recipient!: string
+
+  @ApiProperty()
+  sentBy!: string
+
+  @ApiProperty()
+  body!: string
+
+  @ApiPropertyOptional({ nullable: true })
+  errorMessage!: string | null
+
+  @ApiProperty()
+  timestamp!: Date
+
+  @ApiProperty()
+  notificationStatusId!: string
+
+  @ApiPropertyOptional({ type: () => NotificationLogRelationResponseDto, nullable: true })
+  notificationStatus!: NotificationLogRelationResponseDto | null
+
+  @ApiProperty()
+  notificationTypeId!: string
+
+  @ApiPropertyOptional({ type: () => NotificationLogRelationResponseDto, nullable: true })
+  notificationType!: NotificationLogRelationResponseDto | null
+}

--- a/backend/src/modules/notifications/dto/notification-log-response.dto.ts
+++ b/backend/src/modules/notifications/dto/notification-log-response.dto.ts
@@ -1,12 +1,5 @@
+import { NotificationRelationResponseDto } from '@/modules/notifications/dto/notification-relation-response.dto'
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
-
-class NotificationLogRelationResponseDto {
-  @ApiProperty()
-  id!: string
-
-  @ApiProperty()
-  name!: string
-}
 
 export class NotificationLogResponseDto {
   @ApiProperty()
@@ -21,7 +14,7 @@ export class NotificationLogResponseDto {
   @ApiProperty()
   body!: string
 
-  @ApiPropertyOptional({ nullable: true })
+  @ApiPropertyOptional({ type: String, nullable: true })
   errorMessage!: string | null
 
   @ApiProperty()
@@ -30,12 +23,12 @@ export class NotificationLogResponseDto {
   @ApiProperty()
   notificationStatusId!: string
 
-  @ApiPropertyOptional({ type: () => NotificationLogRelationResponseDto, nullable: true })
-  notificationStatus!: NotificationLogRelationResponseDto | null
+  @ApiPropertyOptional({ type: () => NotificationRelationResponseDto, nullable: true })
+  notificationStatus!: NotificationRelationResponseDto | null
 
   @ApiProperty()
   notificationTypeId!: string
 
-  @ApiPropertyOptional({ type: () => NotificationLogRelationResponseDto, nullable: true })
-  notificationType!: NotificationLogRelationResponseDto | null
+  @ApiPropertyOptional({ type: () => NotificationRelationResponseDto, nullable: true })
+  notificationType!: NotificationRelationResponseDto | null
 }

--- a/backend/src/modules/notifications/dto/notification-relation-response.dto.ts
+++ b/backend/src/modules/notifications/dto/notification-relation-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class NotificationRelationResponseDto {
+  @ApiProperty()
+  id!: string
+
+  @ApiProperty()
+  name!: string
+}

--- a/backend/src/modules/notifications/dto/template-response.dto.ts
+++ b/backend/src/modules/notifications/dto/template-response.dto.ts
@@ -1,0 +1,37 @@
+import { NotificationRelationResponseDto } from '@/modules/notifications/dto/notification-relation-response.dto'
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
+
+export class TemplateResponseDto {
+  @ApiProperty()
+  id!: string
+
+  @ApiProperty()
+  name!: string
+
+  @ApiPropertyOptional({ type: String, nullable: true })
+  description!: string | null
+
+  @ApiProperty()
+  subject!: string
+
+  @ApiProperty()
+  body!: string
+
+  @ApiPropertyOptional({ nullable: true })
+  variableSchema!: Record<string, string> | null
+
+  @ApiProperty()
+  isActive!: boolean
+
+  @ApiProperty()
+  createdAt!: Date
+
+  @ApiPropertyOptional({ type: Date, nullable: true })
+  updatedAt!: Date | null
+
+  @ApiProperty()
+  notificationTypeId!: string
+
+  @ApiPropertyOptional({ type: () => NotificationRelationResponseDto, nullable: true })
+  notificationType!: NotificationRelationResponseDto | null
+}

--- a/backend/src/modules/notifications/dto/update-template.dto.ts
+++ b/backend/src/modules/notifications/dto/update-template.dto.ts
@@ -1,0 +1,44 @@
+import { UpdateTemplateInput } from '@/modules/notifications/inputs/update-template.input'
+import { ApiProperty } from '@nestjs/swagger'
+import { IsBoolean, IsObject, IsString, ValidateIf } from 'class-validator'
+
+// O MS exige as 7 chaves presentes no corpo do PUT, mesmo que o valor seja null
+// (não aceita corpo parcial hoje — ver relatório de bug). Por isso, diferente dos
+// outros DTOs de update do projeto, nenhum campo aqui é @IsOptional(): a chave é
+// obrigatória, só o valor pode ser null.
+export class UpdateTemplateDto implements UpdateTemplateInput {
+  @ApiProperty({ description: 'Template name', type: String, nullable: true })
+  @ValidateIf((_, value) => value !== null)
+  @IsString({ message: 'O nome do template deve ser um texto.' })
+  name!: string | null
+
+  @ApiProperty({ description: 'Template description', type: String, nullable: true })
+  @ValidateIf((_, value) => value !== null)
+  @IsString({ message: 'A descrição do template deve ser um texto.' })
+  description!: string | null
+
+  @ApiProperty({ description: 'E-mail subject', type: String, nullable: true })
+  @ValidateIf((_, value) => value !== null)
+  @IsString({ message: 'O assunto do template deve ser um texto.' })
+  subject!: string | null
+
+  @ApiProperty({ description: 'Template body (HTML)', type: String, nullable: true })
+  @ValidateIf((_, value) => value !== null)
+  @IsString({ message: 'O corpo do template deve ser um texto.' })
+  body!: string | null
+
+  @ApiProperty({ description: 'Variables accepted by the template', nullable: true })
+  @ValidateIf((_, value) => value !== null)
+  @IsObject({ message: 'O esquema de variáveis deve ser um objeto.' })
+  variableSchema!: Record<string, string> | null
+
+  @ApiProperty({ description: 'Whether the template is active', type: Boolean, nullable: true })
+  @ValidateIf((_, value) => value !== null)
+  @IsBoolean({ message: 'O campo ativo deve ser um booleano.' })
+  isActive!: boolean | null
+
+  @ApiProperty({ description: 'Notification type id', type: String, nullable: true })
+  @ValidateIf((_, value) => value !== null)
+  @IsString({ message: 'O ID do tipo de notificação deve ser um texto.' })
+  notificationTypeId!: string | null
+}

--- a/backend/src/modules/notifications/entities/notification-log.ts
+++ b/backend/src/modules/notifications/entities/notification-log.ts
@@ -1,7 +1,7 @@
-type NotificationLogRelationMsPayload = {
-  id: string
-  name: string
-}
+import {
+  NotificationRelation,
+  type NotificationRelationMsPayload,
+} from '@/modules/notifications/entities/notification-relation'
 
 type NotificationLogMsPayload = {
   id: string
@@ -11,16 +11,9 @@ type NotificationLogMsPayload = {
   error_message: string | null
   timestamp: string
   notification_status_id: string
-  notification_status?: NotificationLogRelationMsPayload | null
+  notification_status?: NotificationRelationMsPayload | null
   notification_type_id: string
-  notification_type?: NotificationLogRelationMsPayload | null
-}
-
-export class NotificationLogRelation {
-  constructor(
-    public readonly id: string,
-    public readonly name: string,
-  ) {}
+  notification_type?: NotificationRelationMsPayload | null
 }
 
 export class NotificationLog {
@@ -33,8 +26,8 @@ export class NotificationLog {
     public readonly timestamp: Date,
     public readonly notificationStatusId: string,
     public readonly notificationTypeId: string,
-    public readonly notificationStatus: NotificationLogRelation | null,
-    public readonly notificationType: NotificationLogRelation | null,
+    public readonly notificationStatus: NotificationRelation | null,
+    public readonly notificationType: NotificationRelation | null,
   ) {}
 
   static fromMs(raw: NotificationLogMsPayload): NotificationLog {
@@ -47,12 +40,8 @@ export class NotificationLog {
       new Date(raw.timestamp),
       raw.notification_status_id,
       raw.notification_type_id,
-      raw.notification_status
-        ? new NotificationLogRelation(raw.notification_status.id, raw.notification_status.name)
-        : null,
-      raw.notification_type
-        ? new NotificationLogRelation(raw.notification_type.id, raw.notification_type.name)
-        : null,
+      raw.notification_status ? NotificationRelation.fromMs(raw.notification_status) : null,
+      raw.notification_type ? NotificationRelation.fromMs(raw.notification_type) : null,
     )
   }
 }

--- a/backend/src/modules/notifications/entities/notification-log.ts
+++ b/backend/src/modules/notifications/entities/notification-log.ts
@@ -1,0 +1,60 @@
+type NotificationLogRelationMsPayload = {
+  id: string
+  name: string
+}
+
+type NotificationLogMsPayload = {
+  id: string
+  recipient: string
+  sent_by: string
+  body: string
+  error_message: string | null
+  timestamp: string
+  notification_status_id: string
+  notification_status?: NotificationLogRelationMsPayload | null
+  notification_type_id: string
+  notification_type?: NotificationLogRelationMsPayload | null
+}
+
+export class NotificationLogRelation {
+  constructor(
+    public readonly id: string,
+    public readonly name: string,
+  ) {}
+}
+
+export class NotificationLog {
+  constructor(
+    public readonly id: string,
+    public readonly recipient: string,
+    public readonly sentBy: string,
+    public readonly body: string,
+    public readonly errorMessage: string | null,
+    public readonly timestamp: Date,
+    public readonly notificationStatusId: string,
+    public readonly notificationTypeId: string,
+    public readonly notificationStatus: NotificationLogRelation | null,
+    public readonly notificationType: NotificationLogRelation | null,
+  ) {}
+
+  static fromMs(raw: NotificationLogMsPayload): NotificationLog {
+    return new NotificationLog(
+      raw.id,
+      raw.recipient,
+      raw.sent_by,
+      raw.body,
+      raw.error_message ?? null,
+      new Date(raw.timestamp),
+      raw.notification_status_id,
+      raw.notification_type_id,
+      raw.notification_status
+        ? new NotificationLogRelation(raw.notification_status.id, raw.notification_status.name)
+        : null,
+      raw.notification_type
+        ? new NotificationLogRelation(raw.notification_type.id, raw.notification_type.name)
+        : null,
+    )
+  }
+}
+
+export type { NotificationLogMsPayload }

--- a/backend/src/modules/notifications/entities/notification-relation.ts
+++ b/backend/src/modules/notifications/entities/notification-relation.ts
@@ -1,0 +1,15 @@
+export type NotificationRelationMsPayload = {
+  id: string
+  name: string
+}
+
+export class NotificationRelation {
+  constructor(
+    public readonly id: string,
+    public readonly name: string,
+  ) {}
+
+  static fromMs(raw: NotificationRelationMsPayload): NotificationRelation {
+    return new NotificationRelation(raw.id, raw.name)
+  }
+}

--- a/backend/src/modules/notifications/entities/template.ts
+++ b/backend/src/modules/notifications/entities/template.ts
@@ -1,0 +1,52 @@
+import {
+  NotificationRelation,
+  type NotificationRelationMsPayload,
+} from '@/modules/notifications/entities/notification-relation'
+
+type TemplateMsPayload = {
+  id: string
+  name: string
+  description: string | null
+  subject: string
+  body: string
+  variable_schema: Record<string, string> | null
+  is_active: boolean
+  created_at: string
+  updated_at: string | null
+  notification_type_id: string
+  notification_type?: NotificationRelationMsPayload | null
+}
+
+export class Template {
+  constructor(
+    public readonly id: string,
+    public readonly name: string,
+    public readonly description: string | null,
+    public readonly subject: string,
+    public readonly body: string,
+    public readonly variableSchema: Record<string, string> | null,
+    public readonly isActive: boolean,
+    public readonly createdAt: Date,
+    public readonly updatedAt: Date | null,
+    public readonly notificationTypeId: string,
+    public readonly notificationType: NotificationRelation | null,
+  ) {}
+
+  static fromMs(raw: TemplateMsPayload): Template {
+    return new Template(
+      raw.id,
+      raw.name,
+      raw.description ?? null,
+      raw.subject,
+      raw.body,
+      raw.variable_schema ?? null,
+      raw.is_active,
+      new Date(raw.created_at),
+      raw.updated_at ? new Date(raw.updated_at) : null,
+      raw.notification_type_id,
+      raw.notification_type ? NotificationRelation.fromMs(raw.notification_type) : null,
+    )
+  }
+}
+
+export type { TemplateMsPayload }

--- a/backend/src/modules/notifications/inputs/create-template.input.ts
+++ b/backend/src/modules/notifications/inputs/create-template.input.ts
@@ -1,0 +1,9 @@
+export interface CreateTemplateInput {
+  name: string
+  description: string | null
+  subject: string
+  body: string
+  variableSchema?: Record<string, string>
+  isActive?: boolean
+  notificationTypeId?: string
+}

--- a/backend/src/modules/notifications/inputs/update-template.input.ts
+++ b/backend/src/modules/notifications/inputs/update-template.input.ts
@@ -1,0 +1,12 @@
+// O MS de notificações (branch features/template) exige as 7 chaves presentes no PUT
+// mesmo que o valor seja null — não aceita omitir campos (ver relatório de bug).
+// Por isso esse input espelha esse contrato: nenhum campo é opcional, todos aceitam null.
+export interface UpdateTemplateInput {
+  name: string | null
+  description: string | null
+  subject: string | null
+  body: string | null
+  variableSchema: Record<string, string> | null
+  isActive: boolean | null
+  notificationTypeId: string | null
+}

--- a/backend/src/modules/notifications/notifications-ms.client.ts
+++ b/backend/src/modules/notifications/notifications-ms.client.ts
@@ -3,6 +3,9 @@ import {
   NotificationLog,
   type NotificationLogMsPayload,
 } from '@/modules/notifications/entities/notification-log'
+import { Template, type TemplateMsPayload } from '@/modules/notifications/entities/template'
+import type { CreateTemplateInput } from '@/modules/notifications/inputs/create-template.input'
+import type { UpdateTemplateInput } from '@/modules/notifications/inputs/update-template.input'
 import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common'
 import { JwtService } from '@nestjs/jwt'
 
@@ -25,6 +28,24 @@ export class NotificationsMsClient {
     })
 
     return raw.map((item) => NotificationLog.fromMs(item))
+  }
+
+  async createTemplate(payload: CreateTemplateInput): Promise<Template> {
+    const raw = await this.request<TemplateMsPayload>('/template/', {
+      method: 'POST',
+      body: payload,
+    })
+
+    return Template.fromMs(raw)
+  }
+
+  async updateTemplate(templateId: string, payload: UpdateTemplateInput): Promise<Template> {
+    const raw = await this.request<TemplateMsPayload>(`/template/${templateId}`, {
+      method: 'PUT',
+      body: payload,
+    })
+
+    return Template.fromMs(raw)
   }
 
   private async request<T>(path: string, options: MsRequestOptions): Promise<T> {

--- a/backend/src/modules/notifications/notifications-ms.client.ts
+++ b/backend/src/modules/notifications/notifications-ms.client.ts
@@ -1,0 +1,111 @@
+import { environment } from '@/common/config/environment'
+import {
+  NotificationLog,
+  type NotificationLogMsPayload,
+} from '@/modules/notifications/entities/notification-log'
+import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common'
+import { JwtService } from '@nestjs/jwt'
+
+const REQUEST_TIMEOUT_MS = 7000
+
+type MsRequestOptions = {
+  method: 'GET' | 'POST' | 'PUT'
+  body?: unknown
+}
+
+@Injectable()
+export class NotificationsMsClient {
+  private readonly logger = new Logger(NotificationsMsClient.name)
+
+  constructor(private readonly jwtService: JwtService) {}
+
+  async getNotificationLogs(): Promise<NotificationLog[]> {
+    const raw = await this.request<NotificationLogMsPayload[]>('/notifications/', {
+      method: 'GET',
+    })
+
+    return raw.map((item) => NotificationLog.fromMs(item))
+  }
+
+  private async request<T>(path: string, options: MsRequestOptions): Promise<T> {
+    if (!environment.NOTIFICATIONS_API_URL) {
+      throw new ServiceUnavailableException('Serviço de notificações não está configurado.')
+    }
+
+    const headers: Record<string, string> = {}
+    const authHeader = await this.buildAuthorizationHeader()
+
+    if (authHeader) {
+      headers.Authorization = authHeader
+    }
+
+    if (options.body !== undefined) {
+      headers['Content-Type'] = 'application/json'
+    }
+
+    const controller = new AbortController()
+
+    const timeout = setTimeout(() => {
+      controller.abort()
+    }, REQUEST_TIMEOUT_MS)
+
+    try {
+      const response = await fetch(`${environment.NOTIFICATIONS_API_URL}${path}`, {
+        method: options.method,
+        headers,
+        body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+        signal: controller.signal,
+      })
+
+      clearTimeout(timeout)
+
+      if (!response.ok) {
+        const responseBody = await response.text()
+
+        this.logger.warn(`Notification service responded with ${response.status}: ${responseBody}`)
+
+        throw new ServiceUnavailableException(
+          'Não foi possível obter os dados do serviço de notificações. Tente novamente mais tarde.',
+        )
+      }
+
+      return (await response.json()) as T
+    } catch (error) {
+      clearTimeout(timeout)
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        this.logger.warn('Notification service timeout after 7 seconds')
+
+        throw new ServiceUnavailableException(
+          'O serviço de notificações demorou para responder. Tente novamente mais tarde.',
+        )
+      }
+
+      if (error instanceof ServiceUnavailableException) {
+        throw error
+      }
+
+      this.logger.warn(`Failed to call notification service: ${String(error)}`)
+
+      throw new ServiceUnavailableException(
+        'Não foi possível comunicar com o serviço de notificações. Tente novamente mais tarde.',
+      )
+    }
+  }
+
+  private async buildAuthorizationHeader(): Promise<string | null> {
+    if (!environment.JWT_SECRET) {
+      return null
+    }
+
+    const token = await this.jwtService.signAsync(
+      { features: ['notification-service'] },
+      {
+        secret: environment.JWT_SECRET,
+        expiresIn: environment.JWT_EXPIRES_IN_SECONDS,
+      },
+    )
+
+    return `Bearer ${token}`
+  }
+}

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -1,0 +1,15 @@
+import { NotificationsService } from '@/modules/notifications/services/notifications.service'
+import { Controller, Get } from '@nestjs/common'
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
+
+@ApiBearerAuth()
+@ApiTags('Notifications')
+@Controller('notifications')
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Get('logs')
+  getLogs() {
+    return this.notificationsService.getLogs()
+  }
+}

--- a/backend/src/modules/notifications/notifications.controller.ts
+++ b/backend/src/modules/notifications/notifications.controller.ts
@@ -1,5 +1,7 @@
+import { CreateTemplateDto } from '@/modules/notifications/dto/create-template.dto'
+import { UpdateTemplateDto } from '@/modules/notifications/dto/update-template.dto'
 import { NotificationsService } from '@/modules/notifications/services/notifications.service'
-import { Controller, Get } from '@nestjs/common'
+import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
 
 @ApiBearerAuth()
@@ -11,5 +13,15 @@ export class NotificationsController {
   @Get('logs')
   getLogs() {
     return this.notificationsService.getLogs()
+  }
+
+  @Post('templates')
+  createTemplate(@Body() input: CreateTemplateDto) {
+    return this.notificationsService.createTemplate(input)
+  }
+
+  @Put('templates/:id')
+  updateTemplate(@Param('id') id: string, @Body() input: UpdateTemplateDto) {
+    return this.notificationsService.updateTemplate(id, input)
   }
 }

--- a/backend/src/modules/notifications/notifications.module.ts
+++ b/backend/src/modules/notifications/notifications.module.ts
@@ -1,0 +1,20 @@
+import { environment } from '@/common/config/environment'
+import { Module } from '@nestjs/common'
+import { JwtModule } from '@nestjs/jwt'
+import { NotificationsMsClient } from './notifications-ms.client'
+import { NotificationsController } from './notifications.controller'
+import { NotificationsService } from './services/notifications.service'
+
+@Module({
+  imports: [
+    JwtModule.register({
+      secret: environment.JWT_SECRET,
+      signOptions: {
+        expiresIn: environment.JWT_EXPIRES_IN_SECONDS,
+      },
+    }),
+  ],
+  controllers: [NotificationsController],
+  providers: [NotificationsService, NotificationsMsClient],
+})
+export class NotificationsModule {}

--- a/backend/src/modules/notifications/services/notifications.service.ts
+++ b/backend/src/modules/notifications/services/notifications.service.ts
@@ -1,5 +1,9 @@
+import { CreateTemplateDto } from '@/modules/notifications/dto/create-template.dto'
 import { NotificationLogResponseDto } from '@/modules/notifications/dto/notification-log-response.dto'
+import { TemplateResponseDto } from '@/modules/notifications/dto/template-response.dto'
+import { UpdateTemplateDto } from '@/modules/notifications/dto/update-template.dto'
 import { NotificationLog } from '@/modules/notifications/entities/notification-log'
+import { Template } from '@/modules/notifications/entities/template'
 import { NotificationsMsClient } from '@/modules/notifications/notifications-ms.client'
 import { Injectable } from '@nestjs/common'
 
@@ -9,10 +13,20 @@ export class NotificationsService {
 
   async getLogs(): Promise<NotificationLogResponseDto[]> {
     const logs = await this.notificationsMsClient.getNotificationLogs()
-    return logs.map((log) => this.toResponse(log))
+    return logs.map((log) => this.toLogResponse(log))
   }
 
-  private toResponse(log: NotificationLog): NotificationLogResponseDto {
+  async createTemplate(input: CreateTemplateDto): Promise<TemplateResponseDto> {
+    const template = await this.notificationsMsClient.createTemplate(input)
+    return this.toTemplateResponse(template)
+  }
+
+  async updateTemplate(templateId: string, input: UpdateTemplateDto): Promise<TemplateResponseDto> {
+    const template = await this.notificationsMsClient.updateTemplate(templateId, input)
+    return this.toTemplateResponse(template)
+  }
+
+  private toLogResponse(log: NotificationLog): NotificationLogResponseDto {
     return {
       id: log.id,
       recipient: log.recipient,
@@ -24,6 +38,22 @@ export class NotificationsService {
       notificationStatus: log.notificationStatus,
       notificationTypeId: log.notificationTypeId,
       notificationType: log.notificationType,
+    }
+  }
+
+  private toTemplateResponse(template: Template): TemplateResponseDto {
+    return {
+      id: template.id,
+      name: template.name,
+      description: template.description,
+      subject: template.subject,
+      body: template.body,
+      variableSchema: template.variableSchema,
+      isActive: template.isActive,
+      createdAt: template.createdAt,
+      updatedAt: template.updatedAt,
+      notificationTypeId: template.notificationTypeId,
+      notificationType: template.notificationType,
     }
   }
 }

--- a/backend/src/modules/notifications/services/notifications.service.ts
+++ b/backend/src/modules/notifications/services/notifications.service.ts
@@ -1,0 +1,29 @@
+import { NotificationLogResponseDto } from '@/modules/notifications/dto/notification-log-response.dto'
+import { NotificationLog } from '@/modules/notifications/entities/notification-log'
+import { NotificationsMsClient } from '@/modules/notifications/notifications-ms.client'
+import { Injectable } from '@nestjs/common'
+
+@Injectable()
+export class NotificationsService {
+  constructor(private readonly notificationsMsClient: NotificationsMsClient) {}
+
+  async getLogs(): Promise<NotificationLogResponseDto[]> {
+    const logs = await this.notificationsMsClient.getNotificationLogs()
+    return logs.map((log) => this.toResponse(log))
+  }
+
+  private toResponse(log: NotificationLog): NotificationLogResponseDto {
+    return {
+      id: log.id,
+      recipient: log.recipient,
+      sentBy: log.sentBy,
+      body: log.body,
+      errorMessage: log.errorMessage,
+      timestamp: log.timestamp,
+      notificationStatusId: log.notificationStatusId,
+      notificationStatus: log.notificationStatus,
+      notificationTypeId: log.notificationTypeId,
+      notificationType: log.notificationType,
+    }
+  }
+}


### PR DESCRIPTION
Closes #76 
Closes #77 
Closes #78 

Bugs encontrados integrando com notifications-ms (branch features/template)

1. Campos sem = None tornam obrigatórias chaves que deveriam ser opcionais
Arquivo: app/models/requests/template_request.py
CreateTemplateRequest.description: str | None — sem default.
UpdateTemplateRequest — todos os 7 campos (str | None, bool | None, dict[str,str] | None) sem default.
No Pydantic v2, isso torna a chave obrigatória no payload (só o valor pode ser None). Reproduzido localmente com Pydantic 2.13 (mesma major do pydantic==2.12.4 pinned): um PUT parcial, com só {"name": "..."}, é rejeitado com 422 pedindo os outros 6 campos. Isso contradiz TemplateService.update_template (app/services/template_service.py), que usa payload.model_dump(exclude_unset=True) — lógica que só faz sentido se updates parciais fossem aceitos.
Fix: adicionar = None em cada campo opcional dos dois request models.


2. update_template não relê o banco — resposta pode trazer dado errado, e não detecta ID inexistente
Arquivo: app/services/template_service.py, método update_template.
Depois do UPDATE ... WHERE id = template_id, o retorno é Template(id=template_id, **data) — um objeto novo em memória, nunca lido de volta do banco. Consequências:
created_at na resposta vem da default_factory (parece que o template foi "criado agora").
updated_at vem None, mesmo que a coluna real seja atualizada pelo onupdate do SQLAlchemy.
notification_type (relação) não vem populado.
Atualizar um template_id inexistente não retorna 404 — a query afeta 0 linhas silenciosamente e a função ainda devolve um Template de "sucesso" fabricado.
Fix sugerido: reler o registro do banco (await self._session.get(Template, template_id)) e levantar 404 se não existir, antes de retornar.


3. templateId só é aplicado para Email (SMTP) — BrevoEmail, SMS e WhatsApp ignoram o template
Arquivos: app/strategies/brevo_email.py, sms.py, whatsapp.py vs email.py.
Só EmailStrategy.apply_template de fato substitui as variáveis (render_template, regex {{var}}) no subject/body a partir do template. BrevoEmailStrategy.apply_template, SMSStrategy.apply_template e WhatsappStrategy.apply_template são no-op (return request sem nenhuma alteração).
Impacto prático: o projeto insurance-management usa notificationTypeId: "BrevoEmail" hoje. Se alguém chamar POST /notifications/send com templateId e type: BrevoEmail sem emailBody/subject (permitido pela validação quando templateId é informado), o Brevo vai receber subject/htmlContent nulos, porque BrevoEmailStrategy nunca preenche esses campos a partir do template.


Fix sugerido: implementar apply_template em BrevoEmailStrategy reaproveitando render_template de app/strategies/base.py, do jeito que EmailStrategy já faz.